### PR TITLE
clean up unused endpoints

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -1,9 +1,9 @@
 import mdx from '@astrojs/mdx';
 import node from '@astrojs/node';
-import partytown from '@astrojs/partytown';
 import sitemap from '@astrojs/sitemap';
-import { defineConfig, envField } from 'astro/config';
+import configConst from '@utils/site-info';
 
+import { defineConfig, envField } from 'astro/config';
 import icons from 'astro-icon';
 import unocss from 'unocss/astro';
 
@@ -20,7 +20,6 @@ export default defineConfig({
 		}),
 		mdx(),
 		sitemap(),
-		partytown(),
 		icons({
 			svgoOptions: {
 				plugins: [],
@@ -34,7 +33,7 @@ export default defineConfig({
 		contentIntellisense: true,
 	},
 	redirects: {
-		'/discord': 'https://discord.gg/N4qW7TW3dv',
+		'/discord': configConst.socials.discord,
 		'/oneconfig': '/projects/oneconfig',
 		'/oneclient-blog': '/blog/oneclient-announcement',
 	},

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -8,14 +8,12 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"check": "astro check",
-		"astro": "astro",
-		"test": "vitest"
+		"astro": "astro"
 	},
 	"dependencies": {
 		"@astrojs/check": "^0.9.4",
 		"@astrojs/mdx": "^4.3.1",
 		"@astrojs/node": "^9.3.0",
-		"@astrojs/partytown": "^2.1.4",
 		"@astrojs/rss": "^4.0.12",
 		"@astrojs/sitemap": "^3.4.1",
 		"@octokit/core": "^7.0.6",

--- a/apps/website/src/pages/api/releases/oneconfig/loader/[version].ts
+++ b/apps/website/src/pages/api/releases/oneconfig/loader/[version].ts
@@ -1,6 +1,0 @@
-import type { APIRoute } from 'astro';
-
-export const prerender = false;
-export const GET: APIRoute = async () => {
-	return Response.json({ message: 'hi there' }, { status: 301 });
-};

--- a/apps/website/src/pages/chat.ts
+++ b/apps/website/src/pages/chat.ts
@@ -1,3 +1,0 @@
-import type { APIRoute } from 'astro';
-
-export const GET: APIRoute = async ({ redirect }) => redirect('https://discord.gg/');

--- a/apps/website/src/pages/discord.ts
+++ b/apps/website/src/pages/discord.ts
@@ -1,4 +1,0 @@
-import type { APIRoute } from 'astro';
-import configConst from '@utils/site-info';
-
-export const GET: APIRoute = async ({ redirect }) => redirect(configConst.socials.discord);

--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -1,9 +1,0 @@
-/// <reference types="vitest/config" />
-import { getViteConfig } from 'astro/config';
-
-export default getViteConfig({
-	test: {
-		globals: true,
-		reporters: ['dot'],
-	},
-});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"eslint": "^9.39.3",
 		"eslint-plugin-astro": "^1.6.0",
 		"eslint-plugin-jsx-a11y": "^6.10.2",
-		"vite": "^7.3.1",
-		"vitest": "^3.2.4"
+		"vite": "^7.3.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@24.0.15)(jiti@2.4.2)(sass@1.89.2)(terser@5.32.0)(tsx@4.19.0)(yaml@2.8.2)
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.15)(jiti@2.4.2)(sass@1.89.2)(terser@5.32.0)(tsx@4.19.0)(yaml@2.8.2)
 
   apps/website:
     dependencies:
@@ -44,9 +41,6 @@ importers:
       '@astrojs/node':
         specifier: ^9.3.0
         version: 9.3.0(astro@5.12.0(@types/node@24.0.15)(jiti@2.4.2)(rollup@4.59.0)(sass@1.89.2)(terser@5.32.0)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.2))
-      '@astrojs/partytown':
-        specifier: ^2.1.4
-        version: 2.1.4
       '@astrojs/rss':
         specifier: ^4.0.12
         version: 4.0.12
@@ -146,9 +140,6 @@ packages:
     resolution: {integrity: sha512-IV8NzGStHAsKBz1ljxxD8PBhBfnw/BEx/PZfsncTNXg9D4kQtZbSy+Ak0LvDs+rPmK0VeXLNn0HAdWuHCVg8cw==}
     peerDependencies:
       astro: ^5.3.0
-
-  '@astrojs/partytown@2.1.4':
-    resolution: {integrity: sha512-loUrAu0cGYFDC6dHVRiomdsBJ41VjDYXPA+B3Br51V5hENFgDSOLju86OIj1TvBACcsB22UQV7BlppODDG5gig==}
 
   '@astrojs/prism@3.3.0':
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
@@ -1284,11 +1275,6 @@ packages:
   '@quansync/fs@0.1.3':
     resolution: {integrity: sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==}
     engines: {node: '>=20.0.0'}
-
-  '@qwik.dev/partytown@0.11.2':
-    resolution: {integrity: sha512-795y49CqBiKiwKAD+QBZlzlqEK275hVcazZ7wBPSfgC23L+vWuA7PJmMpgxojOucZHzYi5rAAQ+IP1I3BKVZxw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -2440,10 +2426,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
 
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
@@ -5346,11 +5328,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/partytown@2.1.4':
-    dependencies:
-      '@qwik.dev/partytown': 0.11.2
-      mrmime: 2.0.1
-
   '@astrojs/prism@3.3.0':
     dependencies:
       prismjs: 1.30.0
@@ -6271,10 +6248,6 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@qwik.dev/partytown@0.11.2':
-    dependencies:
-      dotenv: 16.6.1
-
   '@rollup/pluginutils@5.2.0(rollup@4.59.0)':
     dependencies:
       '@types/estree': 1.0.8
@@ -6418,12 +6391,14 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+    optional: true
 
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
 
-  '@types/deep-eql@4.0.2': {}
+  '@types/deep-eql@4.0.2':
+    optional: true
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -6830,6 +6805,7 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+    optional: true
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.0.15)(jiti@2.4.2)(sass@1.89.2)(terser@5.32.0)(tsx@4.19.0)(yaml@2.8.2))':
     dependencies:
@@ -6838,32 +6814,38 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@24.0.15)(jiti@2.4.2)(sass@1.89.2)(terser@5.32.0)(tsx@4.19.0)(yaml@2.8.2)
+    optional: true
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+    optional: true
 
   '@vitest/runner@3.2.4':
     dependencies:
       '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.1.0
+    optional: true
 
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
+    optional: true
 
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+    optional: true
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+    optional: true
 
   '@volar/kit@2.4.20(typescript@5.6.2)':
     dependencies:
@@ -7100,7 +7082,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  assertion-error@2.0.1: {}
+  assertion-error@2.0.1:
+    optional: true
 
   ast-types-flow@0.0.8: {}
 
@@ -7363,6 +7346,7 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+    optional: true
 
   chalk@4.1.2:
     dependencies:
@@ -7379,7 +7363,8 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  check-error@2.1.3: {}
+  check-error@2.1.3:
+    optional: true
 
   cheerio-select@2.1.0:
     dependencies:
@@ -7585,7 +7570,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  deep-eql@5.0.2: {}
+  deep-eql@5.0.2:
+    optional: true
 
   deep-is@0.1.4: {}
 
@@ -7653,8 +7639,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dotenv@16.6.1: {}
 
   dset@3.1.4: {}
 
@@ -8304,7 +8288,8 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
-  expect-type@1.3.0: {}
+  expect-type@1.3.0:
+    optional: true
 
   exsolve@1.0.7: {}
 
@@ -8917,7 +8902,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1: {}
+  js-tokens@9.0.1:
+    optional: true
 
   js-yaml@4.1.0:
     dependencies:
@@ -9018,7 +9004,8 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
-  loupe@3.2.1: {}
+  loupe@3.2.1:
+    optional: true
 
   lru-cache@10.4.3: {}
 
@@ -9788,7 +9775,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.1: {}
+  pathval@2.0.1:
+    optional: true
 
   pend@1.2.0: {}
 
@@ -10319,7 +10307,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  siginfo@2.0.0: {}
+  siginfo@2.0.0:
+    optional: true
 
   simple-swizzle@0.2.2:
     dependencies:
@@ -10382,13 +10371,15 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
-  stackback@0.0.2: {}
+  stackback@0.0.2:
+    optional: true
 
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@3.10.0:
+    optional: true
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -10460,6 +10451,7 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+    optional: true
 
   strnum@2.1.1: {}
 
@@ -10518,7 +10510,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
-  tinybench@2.9.0: {}
+  tinybench@2.9.0:
+    optional: true
 
   tinyexec@0.3.2: {}
 
@@ -10534,11 +10527,14 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
+  tinypool@1.1.1:
+    optional: true
 
-  tinyrainbow@2.0.0: {}
+  tinyrainbow@2.0.0:
+    optional: true
 
-  tinyspy@4.0.4: {}
+  tinyspy@4.0.4:
+    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10894,6 +10890,7 @@ snapshots:
       - terser
       - tsx
       - yaml
+    optional: true
 
   vite@6.4.1(@types/node@24.0.15)(jiti@2.4.2)(sass@1.89.2)(terser@5.32.0)(tsx@4.19.0)(yaml@2.8.2):
     dependencies:
@@ -10974,6 +10971,7 @@ snapshots:
       - terser
       - tsx
       - yaml
+    optional: true
 
   volar-service-css@0.0.62(@volar/language-service@2.4.20):
     dependencies:
@@ -11181,6 +11179,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+    optional: true
 
   widest-line@5.0.0:
     dependencies:


### PR DESCRIPTION
- remove partytown - analytics were removed [8 months ago](https://github.com/Polyfrost/website/commit/c3b7e442af5d8eaadf27222d3b3f3fab641f0f5b)
- remove vitest - we have no tests and it caused problems with `astro check`
- remove duplicate discord endpoint in favor of astro redirects
- remove `/chat` that redirected to discord.gg (sic)
- remove `/api/releases/oneconfig/loader/[version]` that returned hi there