### PR TITLE
replace linux distros with a more audience centric list

### DIFF
--- a/apps/website/src/components/page/oneclient/OneClientLinuxDownloads.astro
+++ b/apps/website/src/components/page/oneclient/OneClientLinuxDownloads.astro
@@ -111,7 +111,7 @@ const rpmDownloads = downloads.filter(download => download.format === 'rpm');
 <article class="border border-gray-700 rounded-2xl bg-dark-background p-5">
 	<Header class="text-dark-primary" size="md">Debian Package (.deb)</Header>
 	<Paragraph class="mt-1 text-dark-secondary" size="sm">
-		Best for Ubuntu, Debian, Pop!_OS, Linux Mint, and other apt-based distros.
+		Best for Ubuntu, Debian, Linux Mint, ZorinOS, Pop!_OS, and other apt-based distros.
 	</Paragraph>
 	<div class="mt-3 flex flex-wrap gap-2">
 		{
@@ -143,7 +143,7 @@ sudo apt -f install</code></pre>
 <article class="border border-gray-700 rounded-2xl bg-dark-background p-5">
 	<Header class="text-dark-primary" size="md">RPM Package (.rpm)</Header>
 	<Paragraph class="mt-1 text-dark-secondary" size="sm">
-		Best for Fedora, RHEL, Rocky, AlmaLinux, and openSUSE systems.
+		Best for Fedora, Bazzite, Nobara, and openSUSE systems.
 	</Paragraph>
 	<div class="mt-3 flex flex-wrap gap-2">
 		{
@@ -174,7 +174,7 @@ sudo apt -f install</code></pre>
 <article class="border border-gray-700 rounded-2xl bg-dark-background p-5">
 	<Header class="text-dark-primary" size="md">AUR</Header>
 	<Paragraph class="mt-1 text-dark-secondary" size="sm">
-		Best for Arch Linux, Manjaro, EndeavourOS, and other Arch-based distros.
+		Best for Arch Linux, SteamOS, CachyOS, EndeavourOS, and other Arch-based distros.
 	</Paragraph>
 	<div class="mt-4 border border-gray-700 rounded-xl bg-black/20 p-3">
 		<Paragraph class="text-dark-secondary" size="sm">Install the latest release binary:</Paragraph>


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

I've seen it somewhat often where people don't know what distro theirs is based on, especially in more recent times as Linux is becoming more popular. Most of the time these beginner friendly distros have you use their GUI based package manager for select packages or have you install flatpaks via their store. There's a solid group of people that use ZorinOS because it's "the most windows-like" and have no idea its Debian based, and same with Steam Deck users (and eventually Steam Machine) who just got a device to play some games.

With the Fedora list in specific, I didn't see a reason to include any enterprise level distros. These should not be used for gaming. I also removed Manjaro because lol